### PR TITLE
Fix for "cannot find module" problem while generating app

### DIFF
--- a/packages/ext-gen/ext-gen.js
+++ b/packages/ext-gen/ext-gen.js
@@ -600,6 +600,9 @@ async function stepCreate() {
   } catch(err) {
     console.log(boldRed('Error in npm install: ' + err));
   }
+  
+  // Fix: install necessary sencha packages to prevent error before requiring frameworkPath/cmdPath
+  await util.spawnPromise(command,['install','@sencha/ext','@sencha/cmd'], options,[]);
 
   var frameworkPath = path.join(destDir, 'node_modules', npmScope, 'ext', 'package.json');
   var cmdPath = path.join(destDir, 'node_modules', npmScope, 'cmd', 'package.json');


### PR DESCRIPTION
This patch fixes the problem mentioned in issue #155 and the following pages:
- https://www.sencha.com/forum/showthread.php?470984-Generating-ExtJS-6-6-CE-app-failure&p=1324901#post1324901
- https://stackoverflow.com/questions/54724299/unhandledpromiserejectionwarning-error-cannot-find-module-using-ext-gen/56316813#56316813