### PR TITLE
OTOOLS-23 | main.js Script injection tag appended every build pass

### DIFF
--- a/packages/ext-gen/templates/package.json.tpl.default
+++ b/packages/ext-gen/templates/package.json.tpl.default
@@ -55,6 +55,7 @@
     "@babel/preset-env": "^7.5.5",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-loader": "^8.0.6",
-    "lodash.find": "^4.6.0"
+    "lodash.find": "^4.6.0",
+    "replace": "^1.1.1"
   }
 }

--- a/packages/ext-gen/templates/webpack.config.js.tpl.default
+++ b/packages/ext-gen/templates/webpack.config.js.tpl.default
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const ExtWebpackPlugin = require('@sencha/ext-webpack-plugin');
 const portfinder = require('portfinder');
+const replace = require("replace");
 
 module.exports = async function (env) {
   function get(it, val) {if(env == undefined) {return val} else if(env[it] == undefined) {return val} else {return env[it]}}
@@ -36,6 +37,14 @@ module.exports = async function (env) {
   
   if (environment === 'production') { isProd = true; }
   
+  if(isProd) {
+    replace({
+      regex: '<script.+?(?=src)src="main\.js[^<]+<\/script>',
+      replacement: "",
+      paths: ['index.html']
+    });
+  }
+
   portfinder.basePort = (env && env.port) || 1962
   return portfinder.getPortPromise().then(port => {
     const plugins = [


### PR DESCRIPTION
Used npm module 'replace' to remove stale main.js file entries.