### PR TITLE
Sencha CMD shouldn't recompress the webpack output

### DIFF
--- a/packages/ext-build-generate-app/ext-templates/application/classicdesktop/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/classicdesktop/app.json.tpl.default
@@ -94,7 +94,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {

--- a/packages/ext-build-generate-app/ext-templates/application/classicdesktoplogin/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/classicdesktoplogin/app.json.tpl.default
@@ -94,7 +94,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {

--- a/packages/ext-build-generate-app/ext-templates/application/moderndesktop/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/moderndesktop/app.json.tpl.default
@@ -101,7 +101,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {

--- a/packages/ext-build-generate-app/ext-templates/application/moderndesktopminimal/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/moderndesktopminimal/app.json.tpl.default
@@ -91,7 +91,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {

--- a/packages/ext-build-generate-app/ext-templates/application/universalclassicmodern/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/universalclassicmodern/app.json.tpl.default
@@ -104,7 +104,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {

--- a/packages/ext-build-generate-app/ext-templates/application/universalmodern/app.json.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/universalmodern/app.json.tpl.default
@@ -104,7 +104,7 @@
   "production": {
     "js": [
       {"path": "app.js", "bundle": true},
-      {"path": "$\u007bapp.webpack.bundle}"}
+      {"path": "$\u007bapp.webpack.bundle}", "compress": false }
     ],
     "output": {
       "appCache": {


### PR DESCRIPTION
With the default `app.json` that gets generated for new apps, the webpack generated `main.[hash].js` file gets recompressed again. This removes the ability to configure that in the webpack.config.json (e.g. to create a non-compressed version so that you can debug easily).

This PR configures the `app.json` to _not_ compress the `main.[hash].js` file, and instead rely on webpack to do this properly.