### PR TITLE
Support for Ext JS v7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ext-gen",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "ext-gen root",
   "main": "index.js",
   "scripts": {

--- a/packages/ext-build-generate-app/package.json
+++ b/packages/ext-build-generate-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sencha/ext-build-generate-app",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "ext-build-generate-app - app generator for ext-gen and ext-build",
   "main": "generateApp.js",
   "dependencies": {

--- a/packages/ext-build/package.json
+++ b/packages/ext-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sencha/ext-build",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "ext-build - CLI tool for Sencha Ext JS",
   "bin": {
     "ext-build": "bin/ext-build.js"
@@ -10,8 +10,8 @@
     "loglevel": "silent"
   },
   "dependencies": {
-    "@sencha/ext-build-generate-app": "~7.3.0",
-    "@sencha/cmd": "~7.3.0",
+    "@sencha/ext-build-generate-app": "~7.4.0",
+    "@sencha/cmd": "~7.4.0",
     "node-find-folder": "^0.1.32",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.1",

--- a/packages/ext-gen/package.json
+++ b/packages/ext-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sencha/ext-gen",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "An Ext JS code generator",
   "bin": {
     "ext": "ext-gen.js",
@@ -18,7 +18,7 @@
   },
   "preferGlobal": true,
   "dependencies": {
-    "@sencha/ext-build-generate-app": "~7.3.0",
+    "@sencha/ext-build-generate-app": "~7.4.0",
     "command-line-args": "^5.1.1",
     "comment-json": "^2.1.0",
     "cross-spawn": "^6.0.5",

--- a/packages/ext-gen/templates.2/package.json.tpl.default
+++ b/packages/ext-gen/templates.2/package.json.tpl.default
@@ -44,14 +44,14 @@
   },
   "dependencies": {
     <tpl if="modern == true">
-    "@sencha/ext-modern": "~7.3.0",
-    "@sencha/ext-modern-{modernTheme}": "~7.3.0",</tpl><tpl if="classic == true">
-    "@sencha/ext-classic": "~7.3.0",
-    "@sencha/ext-classic-{classicTheme}": "~7.3.0",</tpl>
-    "@sencha/ext": "~7.3.0"
+    "@sencha/ext-modern": "~7.4.0",
+    "@sencha/ext-modern-{modernTheme}": "~7.4.0",</tpl><tpl if="classic == true">
+    "@sencha/ext-classic": "~7.4.0",
+    "@sencha/ext-classic-{classicTheme}": "~7.4.0",</tpl>
+    "@sencha/ext": "~7.4.0"
   },
   "devDependencies": {
-    "@sencha/ext-webpack-plugin": "~7.3.0",
+    "@sencha/ext-webpack-plugin": "~7.4.0",
 
    "html-webpack-plugin": "^3.2.0",
     "cross-env": "^5.2.0",

--- a/packages/ext-gen/templates.2/webpack.config.js.tpl.default
+++ b/packages/ext-gen/templates.2/webpack.config.js.tpl.default
@@ -12,6 +12,7 @@ module.exports = function (env) {
   var browser     = get('browser',     'yes')
   var watch       = get('watch',       'yes')
   var verbose     = get('verbose',     'no')
+  var cmdopts     = get('cmdopts',     '')
   if (environment == 'production') {
     browser = 'no'
     watch = 'no'
@@ -35,7 +36,8 @@ module.exports = function (env) {
         treeshake: treeshake,
         browser: browser,
         watch: watch,
-        verbose: verbose
+        verbose: verbose,
+        cmdopts: cmdopts
       })
     ]
     return {

--- a/packages/ext-gen/templates/package.json.tpl.default
+++ b/packages/ext-gen/templates/package.json.tpl.default
@@ -23,7 +23,7 @@
     "build:desktop": "npm run clean && cross-env webpack --env.profile=desktop --env.environment=production --env.treeshake=yes",
     "build:phone": "npm run clean && cross-env webpack --env.profile=phone --env.environment=production --env.treeshake=yes",
     "testing:desktop": "npm run clean && cross-env webpack --env.treeshake=yes --env.cmdopts=--testing --env.cmdopts=--build=desktop",
-    "testing:phone": "npm run clean && cross-env webpack --env.treeshake=yes --env.cmdopts=--testing --env.cmdopts=--build=phone",
+    "testing:phone": "npm run clean && cross-env webpack --env.treeshake=yes --env.cmdopts=--testing --env.cmdopts=--build=phone"
   },
 </tpl>
 <tpl if="universal == false">
@@ -31,7 +31,7 @@
     "start": "npm run dev",
     "clean": "rimraf build",
     "dev": "webpack-dev-server --env.profile=desktop --env.browser=yes --env.verbose=no",
-    "build": "npm run clean && cross-env webpack --env.profile=desktop --env.environment=production --env.treeshake=yes"
+    "build": "npm run clean && cross-env webpack --env.profile=desktop --env.environment=production --env.treeshake=yes",
     "build:testing": "npm run clean && cross-env webpack --env.profile=desktop --env.treeshake=yes --env.cmdopts=--testing"
   },
 </tpl>

--- a/packages/ext-gen/templates/package.json.tpl.default
+++ b/packages/ext-gen/templates/package.json.tpl.default
@@ -21,7 +21,9 @@
     "dev:desktop": "webpack-dev-server --env.profile=desktop --env.browser=yes --env.verbose=no",
     "dev:phone": "webpack-dev-server --env.profile=phone --env.browser=yes --env.verbose=no",
     "build:desktop": "npm run clean && cross-env webpack --env.profile=desktop --env.environment=production --env.treeshake=yes",
-    "build:phone": "npm run clean && cross-env webpack --env.profile=phone --env.environment=production --env.treeshake=yes"
+    "build:phone": "npm run clean && cross-env webpack --env.profile=phone --env.environment=production --env.treeshake=yes",
+    "testing:desktop": "npm run clean && cross-env webpack --env.treeshake=yes --env.cmdopts=--testing --env.cmdopts=--build=desktop",
+    "testing:phone": "npm run clean && cross-env webpack --env.treeshake=yes --env.cmdopts=--testing --env.cmdopts=--build=phone",
   },
 </tpl>
 <tpl if="universal == false">
@@ -30,6 +32,7 @@
     "clean": "rimraf build",
     "dev": "webpack-dev-server --env.profile=desktop --env.browser=yes --env.verbose=no",
     "build": "npm run clean && cross-env webpack --env.profile=desktop --env.environment=production --env.treeshake=yes"
+    "build:testing": "npm run clean && cross-env webpack --env.profile=desktop --env.treeshake=yes --env.cmdopts=--testing"
   },
 </tpl>
   "dependencies": {

--- a/packages/ext-gen/templates/package.json.tpl.default
+++ b/packages/ext-gen/templates/package.json.tpl.default
@@ -34,14 +34,14 @@
 </tpl>
   "dependencies": {
     <tpl if="modern == true">
-    "@sencha/ext-modern": "~7.3.0",
-    "@sencha/ext-modern-{modernTheme}": "~7.3.0",</tpl><tpl if="classic == true">
-    "@sencha/ext-classic": "~7.3.0",
-    "@sencha/ext-classic-{classicTheme}": "~7.3.0",</tpl>
-    "@sencha/ext": "~7.3.0"
+    "@sencha/ext-modern": "~7.4.0",
+    "@sencha/ext-modern-{modernTheme}": "~7.4.0",</tpl><tpl if="classic == true">
+    "@sencha/ext-classic": "~7.4.0",
+    "@sencha/ext-classic-{classicTheme}": "~7.4.0",</tpl>
+    "@sencha/ext": "~7.4.0"
   },
   "devDependencies": {
-    "@sencha/ext-webpack-plugin": "~7.3.0",
+    "@sencha/ext-webpack-plugin": "~7.4.0",
     "cross-env": "^5.2.0",
     "portfinder": "^1.0.21",
     "webpack": "~4.39.2",

--- a/packages/ext-gen/templates/webpack.config.js.tpl.default
+++ b/packages/ext-gen/templates/webpack.config.js.tpl.default
@@ -30,6 +30,7 @@ module.exports = async function (env) {
   var watch         = get('watch',         'yes')
   var verbose       = get('verbose',       'no')
   var isProd        = false;
+  var cmdopts     = get('cmdopts',     '')
   
   if (environment === 'production') { isProd = true; }
 
@@ -57,7 +58,8 @@ module.exports = async function (env) {
         treeshake: treeshake,
         browser: browser,
         watch: watch,
-        verbose: verbose
+        verbose: verbose,
+        cmdopts: cmdopts
       })
     ]
     return {

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v7.4
+
+* Support for Ext JS v7.4
+* Version numbering in line with other products
+* OTOOLS-61 - Added support to pass Sencha CMD options on npm scripts
+
 ## v7.2
 
 * Support for Ext JS v7.2

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,10 +1,9 @@
 # Release Notes
 
-## v7.4
+## v7.4.0
 
-* Support for Ext JS v7.4
-* Version numbering in line with other products
-* OTOOLS-61 - Added support to pass Sencha CMD options on npm scripts
+* OTOOLS-76 - Open Tooling Support for Ext JS 7.4
+* OTOOLS-61 - ext-webpack-plugin does not support for building using dynamic packages by passing --uses to npm scripts
 
 ## v7.2
 


### PR DESCRIPTION
* Support for Ext JS v7.4
* Version numbering in line with other products
* OTOOLS-61 - Added support to pass Sencha CMD options on npm scripts 

Jira: https://sencha.jira.com/browse/OTOOLS-61
Description: ext-webpack-plugin does not support for building using dynamic packages by passing --uses to npm scripts