### PR TITLE
OTOOLS-61

### DIFF
--- a/packages/ext-build-generate-app/ext-templates/application/classicdesktop/app/desktop/src/view/home/HomeView.js.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/classicdesktop/app/desktop/src/view/home/HomeView.js.tpl.default
@@ -6,7 +6,7 @@ Ext.define('{appName}.view.home.HomeView',{
 	requires: [],
 	extend: 'Ext.Container',
   scrollable: true,
-  html: `Welcome to the Ext JS 7.2 Classic Desktop Template Application!
+  html: `Welcome to the Ext JS Classic Desktop Template Application!
 <br><br><br><br> 
 This template has the standard architecture for a desktop application
 <br><br>

--- a/packages/ext-build-generate-app/ext-templates/application/classicdesktoplogin/app/desktop/src/view/home/HomeView.js.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/classicdesktoplogin/app/desktop/src/view/home/HomeView.js.tpl.default
@@ -6,7 +6,7 @@ Ext.define('{appName}.view.home.HomeView',{
 	requires: [],
 	extend: 'Ext.Container',
   scrollable: true,
-  html: `Welcome to the Ext JS 7.2 Classic Desktop Template Application!
+  html: `Welcome to the Ext JS Classic Desktop Template Application!
 <br><br><br><br> 
 This template has the standard architecture for a desktop application
 <br><br>

--- a/packages/ext-build-generate-app/ext-templates/application/moderndesktop/app/desktop/src/view/home/HomeView.js.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/moderndesktop/app/desktop/src/view/home/HomeView.js.tpl.default
@@ -6,7 +6,7 @@ Ext.define('{appName}.view.home.HomeView',{
 	requires: [],
 	extend: 'Ext.Container',
   scrollable: true,
-  html: `<div style="user-select: text !important;">Welcome to the Ext JS 7.2 Modern Desktop Template Application!
+  html: `<div style="user-select: text !important;">Welcome to the Ext JS Modern Desktop Template Application!
 <br><br>
 This template has the standard architecture for a desktop application
 <br>

--- a/packages/ext-build-generate-app/ext-templates/application/universalclassicmodern/app/desktop/src/view/home/HomeView.js.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/universalclassicmodern/app/desktop/src/view/home/HomeView.js.tpl.default
@@ -6,7 +6,7 @@ Ext.define('{appName}.view.home.HomeView',{
 	requires: [],
 	extend: 'Ext.Container',
   scrollable: true,
-  html: `Welcome to the Ext JS 7.2 Classic Desktop Template Application!
+  html: `Welcome to the Ext JS Classic Desktop Template Application!
 <br><br><br><br> 
 This template has the standard architecture for a desktop application
 <br><br>

--- a/packages/ext-build-generate-app/ext-templates/application/universalmodern/app/desktop/src/view/home/HomeView.js.tpl.default
+++ b/packages/ext-build-generate-app/ext-templates/application/universalmodern/app/desktop/src/view/home/HomeView.js.tpl.default
@@ -7,7 +7,7 @@ Ext.define('{appName}.view.home.HomeView',{
 	extend: 'Ext.Container',
   scrollable: true,
   html: `<div style="user-select: text !important;">
-Welcome to the Ext JS 7.2 Modern Desktop Template Application!
+Welcome to the Ext JS Modern Desktop Template Application!
 <br><br>
 To build a new ViewPackage, type the following in a command window:
 <br>

--- a/packages/ext-gen/templates.2/webpack.config.js.tpl.default
+++ b/packages/ext-gen/templates.2/webpack.config.js.tpl.default
@@ -12,7 +12,7 @@ module.exports = function (env) {
   var browser     = get('browser',     'yes')
   var watch       = get('watch',       'yes')
   var verbose     = get('verbose',     'no')
-  var cmdopts     = get('cmdopts',     '')
+  var cmdopts     = get('cmdopts',     [])
   if (environment == 'production') {
     browser = 'no'
     watch = 'no'

--- a/packages/ext-gen/templates/webpack.config.js.tpl.default
+++ b/packages/ext-gen/templates/webpack.config.js.tpl.default
@@ -30,7 +30,7 @@ module.exports = async function (env) {
   var watch         = get('watch',         'yes')
   var verbose       = get('verbose',       'no')
   var isProd        = false;
-  var cmdopts     = get('cmdopts',     '')
+  var cmdopts     = get('cmdopts',     [])
   
   if (environment === 'production') { isProd = true; }
 


### PR DESCRIPTION
OTOOLS-61 - ext-webpack-plugin does not support for building using dynamic packages by passing --uses to npm scripts
Jira: https://sencha.jira.com/browse/OTOOLS-61

- change cmdopts default type to array
