### PR TITLE
OTOOLS-122: npm 12 compatibility — lazy install.js on first CLI invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ community
 package-lock.json
 misc2
 node_modules
-.claude
-.mcp.json
-CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ community
 package-lock.json
 misc2
 node_modules
+.claude
+.mcp.json
+CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ext-gen root",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npx lerna exec -- \"npm install\" --loglevel warn",
+    "prepare": "npx lerna exec -- \"npm install\" --loglevel warn",
     "increment": "npx lerna publish --skip-git --skip-npm --force-publish",
     "clean": "npx lerna clean",
     "install:clean": "npm cache clear --force && npx lerna clean && npm install"

--- a/packages/ext-gen/ext-gen.js
+++ b/packages/ext-gen/ext-gen.js
@@ -1,6 +1,11 @@
 #! /usr/bin/env node
 //let run = require('./util').run
 
+// npm 12 compatibility: run install.js lazily on first CLI invocation instead of
+// as an npm lifecycle script. install.js self-deletes after running.
+{ const _f = require('fs'), _p = require('path');
+  if (_f.existsSync(_p.join(__dirname, 'install.js'))) { require('./install.js'); } }
+
 const semver = require("semver")
 const npmScope = '@sencha'
 const appMigrate = require('./appMigrate.js')

--- a/packages/ext-gen/install.js
+++ b/packages/ext-gen/install.js
@@ -53,3 +53,6 @@ ext-gen app -t moderndesktop -n ModernApp
 ${classic}
 Run ${boldGreen('ext-gen --help')} to see all options
 `)
+
+// Self-delete so this runs only once (npm 12 compatibility — triggered lazily from ext-gen.js)
+fs.unlinkSync(__filename);

--- a/packages/ext-gen/package.json
+++ b/packages/ext-gen/package.json
@@ -6,9 +6,7 @@
     "ext": "ext-gen.js",
     "ext-gen": "ext-gen.js"
   },
-  "scripts": {
-    "install": "node ./install.js"
-  },
+  "scripts": {},
   "keywords": [
     "Ext JS",
     "ext-gen"


### PR DESCRIPTION
## Findings

npm 12 dropped support for `install` lifecycle scripts in published packages. `@sencha/ext-gen` relied on `scripts.install: "node ./install.js"` to print the post-install welcome message. The root `package.json` used `postinstall` for lerna bootstrap, which is also affected.

## Root cause

- `packages/ext-gen/package.json` had `scripts: { install: "node ./install.js" }` — silently skipped by npm 12
- Root `package.json` used `postinstall` for lerna bootstrap — `prepare` is the correct lifecycle hook under npm 12

## Fix

- Removed `scripts.install` from `packages/ext-gen/package.json`
- Added lazy check at the top of `ext-gen.js`: if `install.js` exists, run it synchronously on the first CLI invocation
- Added `fs.unlinkSync(__filename)` at the end of `install.js` so it self-deletes after running once
- Changed root `package.json` `postinstall` → `prepare`

## Related PRs

- `extjs/SenchaDeploy` [#590](https://github.com/extjs/SenchaDeploy/pull/590) — removes lifecycle scripts from all published ext/cmd packages
- `sencha/ext-allshared` — adds `_runPendingActivations()` to `ext-webpack-plugin` to trigger `activate.js` lazily on first build